### PR TITLE
fix: peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "typescript": ">=3",
-    "eslint": "^7.10.0"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16.0.0"


### PR DESCRIPTION
fixes #29

removes typescript from peer dependencies (not actually needed)
changes eslint to `"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"﻿`
